### PR TITLE
Include the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.30"
 edition = "2021"
 description = "Git AI: Automates commit messages using ChatGPT. Stage your files, and Git AI generates the messages."
 license = "MIT"
+repository = "https://github.com/oleander/git-ai"
 
 [lib]
 name = "ai"


### PR DESCRIPTION
I am trying to ensure that every published Rust crate has the `repository` field in `Cargo.toml` to allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/), and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it.
That in turn will help various tools and potential contributors to find the repository.  See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.
This crate was [found that way](https://rust-digger.code-maven.com/no-homepage-no-repo).
