### PR TITLE
Use structopt instead of clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +144,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -242,6 +262,21 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
@@ -269,7 +304,7 @@ version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -681,7 +716,7 @@ version = "0.1.38"
 dependencies = [
  "anyhow",
  "async-openai",
- "clap",
+ "clap 4.5.4",
  "colored",
  "config",
  "console",
@@ -699,6 +734,7 @@ dependencies = [
  "serde_derive",
  "serde_ini",
  "serde_json",
+ "structopt",
  "tempfile",
  "thiserror",
  "tokio",
@@ -755,9 +791,27 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -925,7 +979,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -1134,7 +1188,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -1299,6 +1353,30 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1694,6 +1772,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -1703,6 +1787,30 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "syn"
@@ -1782,6 +1890,15 @@ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1986,6 +2103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2142,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2137,6 +2266,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2289,12 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1", features = ["derive"] }
 serde_derive = "1.0.203"
 serde_ini = "0.2.0"
 serde_json = "1.0.117"
+structopt = { version = "0.3.26", features = ["color", "suggestions"] }
 thiserror = "1.0.61"
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "macros"] }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,7 @@ use serde::{Deserialize, Serialize};
 use config::{Config, FileFormat};
 use anyhow::{Context, Result};
 use lazy_static::lazy_static;
-use console::{style, Emoji};
-use clap::ArgMatches;
+use console::Emoji;
 
 #[derive(Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub struct App {
@@ -27,10 +26,10 @@ impl App {
 }
 
 lazy_static! {
-  pub static ref CONFIG_DIR: PathBuf = home::home_dir().unwrap().join(".config/git-ai");
-  #[derive(Debug)]
-  pub static ref APP: App = App::new().expect("Failed to load config");
-  pub static ref CONFIG_PATH: PathBuf = CONFIG_DIR.join("config.ini");
+    pub static ref CONFIG_DIR: PathBuf = home::home_dir().unwrap().join(".config/git-ai");
+    #[derive(Debug)]
+    pub static ref APP: App = App::new().expect("Failed to load config");
+    pub static ref CONFIG_PATH: PathBuf = CONFIG_DIR.join("config.ini");
 }
 
 impl App {
@@ -49,9 +48,9 @@ impl App {
       .add_source(config::File::new(CONFIG_PATH.to_str().unwrap(), FileFormat::Ini))
       .set_default("language", "en")?
       .set_default("timeout", 30)?
-      .set_default("max_commit_length", 72)?
-      .set_default("max_tokens", 512)?
-      .set_default("model", "gpt-4-turbo-preview")?
+      .set_default("max-commit-length", 72)?
+      .set_default("max-tokens", 2024)?
+      .set_default("model", "gpt-4o")?
       .build()?;
 
     config
@@ -68,51 +67,30 @@ impl App {
   }
 }
 
-pub fn run(args: &ArgMatches) -> Result<()> {
+pub fn run_model(value: String) -> Result<()> {
   let mut app = App::new()?;
-  match args.subcommand() {
-    Some(("model", args)) => {
-      app.model.clone_from(
-        args
-          .get_one::<String>("<VALUE>")
-          .context("Failed to parse model")?
-      );
-    }
-    Some(("language", args)) => {
-      app.language.clone_from(
-        args
-          .get_one::<String>("<VALUE>")
-          .context("Failed to parse language")?
-      );
-    }
-    Some(("max-tokens", args)) => {
-      app.max_tokens.clone_from(
-        args
-          .get_one("max-tokens")
-          .context("Failed to parse max-tokens")?
-      );
-    }
-    Some(("max-commit-length", args)) => {
-      app.max_commit_length.clone_from(
-        args
-          .get_one("max-commit-length")
-          .context("Failed to parse max-commit-length")?
-      );
-    }
-    Some(("openai-api-key", args)) => {
-      app.openai_api_key.clone_from(&Some(
-        args
-          .get_one::<String>("<VALUE>")
-          .context("Failed to parse openai-api-key")?
-          .to_owned()
-      ));
-    }
-    _ => unreachable!()
-  }
+  app.model = value;
+  println!("{} Configuration option model updated!", Emoji("✨", ":-)"));
+  app.save()
+}
 
-  if let Some(key) = args.subcommand_name() {
-    println!("{} Configuration option {} updated!", Emoji("✨", ":-)"), style(key).italic());
-  }
+pub fn run_max_tokens(max_tokens: usize) -> Result<()> {
+  let mut app = App::new()?;
+  app.max_tokens = max_tokens;
+  println!("{} Configuration option max-tokens updated!", Emoji("✨", ":-)"));
+  app.save()
+}
 
+pub fn run_max_commit_length(max_commit_length: usize) -> Result<()> {
+  let mut app = App::new()?;
+  app.max_commit_length = max_commit_length;
+  println!("{} Configuration option max-commit-length updated!", Emoji("✨", ":-)"));
+  app.save()
+}
+
+pub fn run_openai_api_key(value: String) -> Result<()> {
+  let mut app = App::new()?;
+  app.openai_api_key = Some(value);
+  println!("{} Configuration option openai-api-key updated!", Emoji("✨", ":-)"));
   app.save()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,68 +3,64 @@ mod install;
 mod reinstall;
 mod config;
 
-use clap::{Arg, Command};
+use structopt::StructOpt;
 use anyhow::Result;
 use dotenv::dotenv;
 
-fn cli() -> Command {
-  Command::new("git-ai")
-    .about("A git extension that uses OpenAI to generate commit messages")
-    .subcommand_required(true)
-    .arg_required_else_help(true)
-    .subcommand(
-      Command::new("hook")
-        .about("Installs the git-ai hook")
-        .subcommand(Command::new("install").about("Installs the git-ai hook"))
-        .subcommand(Command::new("uninstall").about("Uninstalls the git-ai hook"))
-        .subcommand(Command::new("reinstall").about("Reinstalls the git-ai hook"))
-    )
-    .subcommand(
-      Command::new("config")
-        .about("Sets or gets configuration values")
-        .subcommand(
-          Command::new("set")
-            .about("Sets a configuration value")
-            .subcommand(
-              Command::new("model").about("Sets the model to use").arg(
-                Arg::new("<VALUE>")
-                  .required(true)
-                  .index(1)
-                  .value_parser(clap::builder::NonEmptyStringValueParser::new())
-              )
-            )
-            .subcommand(
-              Command::new("max-tokens")
-                .about("Sets the maximum number of tokens to use for the diff")
-                .arg(
-                  Arg::new("max-tokens")
-                    .required(true)
-                    .index(1)
-                    .value_parser(clap::value_parser!(usize))
-                )
-            )
-            .subcommand(
-              Command::new("max-commit-length")
-                .about("Sets the maximum length of the commit message")
-                .arg(
-                  Arg::new("max-commit-length")
-                    .required(true)
-                    .index(1)
-                    .value_parser(clap::value_parser!(usize))
-                )
-            )
-            .subcommand(
-              Command::new("openai-api-key")
-                .about("Sets the OpenAI API key")
-                .arg(
-                  Arg::new("<VALUE>")
-                    .required(true)
-                    .index(1)
-                    .value_parser(clap::builder::NonEmptyStringValueParser::new())
-                )
-            )
-        )
-    )
+/// Git AI Command Line Interface
+#[derive(StructOpt)]
+#[structopt(name = "git-ai", about = "A git extension that uses OpenAI to generate commit messages")]
+enum Cli {
+  #[structopt(about = "Installs the git-ai hook")]
+  Hook(HookSubcommand),
+  #[structopt(about = "Sets or gets configuration values")]
+  Config(ConfigSubcommand)
+}
+
+#[derive(StructOpt)]
+enum HookSubcommand {
+  #[structopt(about = "Installs the git-ai hook")]
+  Install,
+  #[structopt(about = "Uninstalls the git-ai hook")]
+  Uninstall,
+  #[structopt(about = "Reinstalls the git-ai hook")]
+  Reinstall
+}
+
+#[derive(StructOpt)]
+enum ConfigSubcommand {
+  #[structopt(about = "Sets a configuration value")]
+  Set(SetSubcommand)
+}
+
+#[derive(StructOpt)]
+enum SetSubcommand {
+  #[structopt(about = "Sets the model to use")]
+  Model(Model),
+
+  #[structopt(about = "Sets the maximum number of tokens to use for the diff")]
+  MaxTokens {
+    #[structopt(help = "The maximum number of tokens", name = "max-tokens")]
+    max_tokens: usize
+  },
+
+  #[structopt(about = "Sets the maximum length of the commit message")]
+  MaxCommitLength {
+    #[structopt(help = "The maximum length of the commit message", name = "max-commit-length")]
+    max_commit_length: usize
+  },
+
+  #[structopt(about = "Sets the OpenAI API key")]
+  OpenaiApiKey {
+    #[structopt(help = "The OpenAI API key", name = "VALUE")]
+    value: String
+  }
+}
+
+#[derive(StructOpt)]
+struct Model {
+  #[structopt(help = "The value to set", name = "VALUE")]
+  value: String
 }
 
 #[tokio::main(flavor = "multi_thread")]
@@ -72,32 +68,39 @@ async fn main() -> Result<()> {
   env_logger::init();
   dotenv().ok();
 
-  let args = cli().get_matches();
+  let args = Cli::from_args();
 
-  match args.subcommand() {
-    Some(("hook", sub)) =>
-      match sub.subcommand() {
-        Some(("install", _)) => {
+  match args {
+    Cli::Hook(sub) =>
+      match sub {
+        HookSubcommand::Install => {
           install::run()?;
         }
-
-        Some(("uninstall", _)) => {
+        HookSubcommand::Uninstall => {
           uninstall::run()?;
         }
-
-        Some(("reinstall", _)) => {
+        HookSubcommand::Reinstall => {
           reinstall::run()?;
         }
-        _ => unreachable!()
       },
-    Some(("config", args)) =>
-      match args.subcommand() {
-        Some(("set", args)) => {
-          config::run(args)?;
-        }
-        _ => unreachable!()
+    Cli::Config(config) =>
+      match config {
+        ConfigSubcommand::Set(set) =>
+          match set {
+            SetSubcommand::Model(model) => {
+              config::run_model(model.value)?;
+            }
+            SetSubcommand::MaxTokens { max_tokens } => {
+              config::run_max_tokens(max_tokens)?;
+            }
+            SetSubcommand::MaxCommitLength { max_commit_length } => {
+              config::run_max_commit_length(max_commit_length)?;
+            }
+            SetSubcommand::OpenaiApiKey { value } => {
+              config::run_openai_api_key(value)?;
+            }
+          },
       },
-    _ => unreachable!()
   }
 
   Ok(())


### PR DESCRIPTION
1. Update dependencies in Cargo.lock: Add new dependencies such as ansi_term, atty, and clap. Update the source and checksum for each package for accurate tracking of dependencies and versions.

2. Upgrade source code in config.rs: Replace the deprecated argument parsing logic with a simplified version. Replace "gpt-4-turbo-preview" with "gpt-4o" to improve model performance.

3. Refactor run function in config.rs: Simplify the logic by removing unnecessary match args subcommand.

4. Improve the command line interface in main.rs: Switch from clap to StructOpt for better CLI functionality. Remove redundant arguments and commands for a cleaner and more efficient CLI.

5. Miscellaneous Changes: Correct some minor typos and inconsistencies, and make max tokens in the app to 2024 from 512 for better performance.