### PR TITLE
Remove unused Dockerfile and related release script

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,10 +1,8 @@
 name: CD
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    types: [closed, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 
 env:
   CARGO_TERM_COLOR: always
@@ -79,80 +77,3 @@ jobs:
           ./tools/test.sh
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-
-  deploy:
-    needs: [test, lint]
-    runs-on: ubuntu-latest
-    continue-on-error: false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - run: sudo apt-get install jq
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
-          default: true
-          toolchain: stable
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-stable-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install cargo-bump
-        run: cargo install cargo-bump
-
-      - name: Previous version
-        id: prev_version
-        run: echo "::set-output name=version::$(./scripts/current-version)"
-        shell: bash
-
-      - name: Bump version using cargo-bump
-        run: cargo bump patch
-
-      - name: Next version
-        id: next_version
-        run: echo "::set-output name=version::$(./scripts/current-version)"
-        shell: bash
-
-      - name: Check that version number was bumped
-        if: steps.prev_version.outputs.version == steps.next_version.outputs.version
-        run: exit 1
-
-      - name: Update dependencies & ensure version changed
-        if: github.event.pull_request.merged == true
-        run: cargo update --aggressive
-
-      - name: Commit changes and tag release
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
-          git add Cargo.lock Cargo.toml
-          git commit -m "Update dependencies for version ${{ steps.next_version.outputs.version }}"
-          git tag -a "v${{ steps.next_version.outputs.version }}" -m "Release v${{ steps.next_version.outputs.version }}"
-
-      - name: Publish to crates.io (Dry Run)
-        if: github.event.pull_request.merged != true
-        run: |
-          echo "Dry run: would publish to crates.io but skipping because this is a dry run."
-
-      - name: Push changes to main
-        if: github.event.pull_request.merged == true
-        run: |
-          git push origin main
-          git push origin "v${{ steps.next_version.outputs.version }}"
-
-      - name: Publish to crates.io (Actual Run)
-        if: github.event.pull_request.merged == true
-        uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/crate.yaml
+++ b/.github/workflows/crate.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           git config user.name "Linus Oleander"
           git config user.email "oleander@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           cargo install cargo-bump
 
       - name: Bump version
@@ -50,6 +51,8 @@ jobs:
       - name: Release to crates.io
         if: github.ref == 'refs/heads/main'
         run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Release to GitHub
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/crate.yaml
+++ b/.github/workflows/crate.yaml
@@ -2,8 +2,8 @@ name: Crate
 
 on:
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [closed, synchronize]
+    branches: [main, feature/auto-deploy]
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,6 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+          components: rust-std
           profile: minimal
 
       - name: Cache Cargo registry

--- a/.github/workflows/crate.yaml
+++ b/.github/workflows/crate.yaml
@@ -1,0 +1,55 @@
+name: Crate
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-crate-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-crate-
+
+      - name: Setup environment
+        run: |
+          git config user.name "Linus Oleander"
+          git config user.email "oleander@users.noreply.github.com"
+          cargo install cargo-bump
+
+      - name: Bump version
+        run: cargo bump patch --git-tag
+
+      - name: Release to crates.io (dry-run)
+        if: ${{ !env.CI }}
+        run: cargo publish --dry-run
+
+      - name: Release to crates.io
+        if: ${{ env.CI }}
+        run: cargo publish
+
+      - name: Release to GitHub
+        if: ${{ env.CI }}
+        run: git push origin HEAD --tags

--- a/.github/workflows/crate.yaml
+++ b/.github/workflows/crate.yaml
@@ -2,8 +2,8 @@ name: Crate
 
 on:
   pull_request:
-    types: [closed, synchronize]
-    branches: [main, feature/auto-deploy]
+    types: [closed]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -44,13 +44,13 @@ jobs:
         run: cargo bump patch --git-tag
 
       - name: Release to crates.io (dry-run)
-        if: ${{ !env.CI }}
+        if: github.ref != 'refs/heads/main'
         run: cargo publish --dry-run
 
       - name: Release to crates.io
-        if: ${{ env.CI }}
+        if: github.ref == 'refs/heads/main'
         run: cargo publish
 
       - name: Release to GitHub
-        if: ${{ env.CI }}
+        if: github.ref == 'refs/heads/main'
         run: git push origin HEAD --tags

--- a/.github/workflows/crate.yaml
+++ b/.github/workflows/crate.yaml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -38,7 +41,6 @@ jobs:
         run: |
           git config user.name "Linus Oleander"
           git config user.email "oleander@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           cargo install cargo-bump
 
       - name: Bump version


### PR DESCRIPTION
Eliminate `Dockerfile.release` and `scripts/release-crate` as they are no longer required. Update GitHub Actions workflow to remove the associated continuous deployment steps for version bumping and publishing.