### PR TITLE
Allow the OpenAI URL to be configurable using an env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
         rust: [nightly, stable]
     runs-on: ${{ matrix.os }}
     continue-on-error: false
+    services:
+      fake-openai:
+        image: fake-openai:latest
+        ports:
+          - 8080:8080
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -91,3 +96,4 @@ jobs:
           cargo test --release
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_URL: http://localhost:8080

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ const DEFAULT_MAX_COMMIT_LENGTH: i64 = 72;
 const DEFAULT_MAX_TOKENS: i64 = 2024;
 const DEFAULT_MODEL: &str = "gpt-4o-mini";
 const DEFAULT_API_KEY: &str = "<PLACE HOLDER FOR YOUR API KEY>";
+const DEFAULT_OPENAI_HOST: &str = "https://api.openai.com/v1";
 
 #[derive(Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub struct App {
@@ -21,7 +22,8 @@ pub struct App {
   pub model:             Option<String>,
   pub max_tokens:        Option<usize>,
   pub max_commit_length: Option<usize>,
-  pub timeout:           Option<usize>
+  pub timeout:           Option<usize>,
+  pub openai_host:       Option<String>
 }
 
 #[derive(Debug)]
@@ -45,10 +47,10 @@ impl ConfigPaths {
   }
 
   fn ensure_exists(&self) -> Result<()> {
-    if !self.dir.exists() {
+    if (!self.dir.exists()) {
       std::fs::create_dir_all(&self.dir).with_context(|| format!("Failed to create config directory at {:?}", self.dir))?;
     }
-    if !self.file.exists() {
+    if (!self.file.exists()) {
       File::create(&self.file).with_context(|| format!("Failed to create config file at {:?}", self.file))?;
     }
     Ok(())
@@ -69,6 +71,7 @@ impl App {
       .set_default("max_tokens", DEFAULT_MAX_TOKENS)?
       .set_default("model", DEFAULT_MODEL)?
       .set_default("openai_api_key", DEFAULT_API_KEY)?
+      .set_default("openai_host", DEFAULT_OPENAI_HOST)?
       .build()?;
 
     config
@@ -102,6 +105,11 @@ impl App {
   pub fn update_openai_api_key(&mut self, value: String) -> Result<()> {
     self.openai_api_key = Some(value);
     self.save_with_message("openai-api-key")
+  }
+
+  pub fn update_openai_host(&mut self, value: String) -> Result<()> {
+    self.openai_host = Some(value);
+    self.save_with_message("openai-host")
   }
 
   fn save_with_message(&self, option: &str) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,12 @@ enum SetSubcommand {
   OpenaiApiKey {
     #[structopt(help = "The OpenAI API key", name = "VALUE")]
     value: String
+  },
+
+  #[structopt(about = "Sets the OpenAI host URL")]
+  Url {
+    #[structopt(default_value = "https://api.openai.com/v1", env = "OPENAI_URL", help = "The OpenAI host URL", name = "VALUE")]
+    value: String
   }
 }
 
@@ -181,6 +187,13 @@ fn run_config_openai_api_key(value: String) -> Result<()> {
   Ok(())
 }
 
+fn run_config_openai_host(value: String) -> Result<()> {
+  let mut app = App::new()?;
+  app.update_openai_host(value)?;
+  println!("✅ OpenAI host URL updated");
+  Ok(())
+}
+
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
   dotenv().ok();
@@ -219,6 +232,9 @@ async fn main() -> Result<()> {
             }
             SetSubcommand::OpenaiApiKey { value } => {
               run_config_openai_api_key(value)?;
+            }
+            SetSubcommand::Url { value } => {
+              run_config_openai_host(value)?;
             }
           },
       },

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -96,7 +96,8 @@ pub async fn call(request: Request) -> Result<Response> {
     "git-ai config set openai-api-key <your-key>".yellow()
   ))?;
 
-  let config = OpenAIConfig::new().with_api_key(api_key);
+  let openai_host = config::APP.openai.host.into());
+  let config = OpenAIConfig::new().with_api_key(api_key).with_base_url(openai_host);
   let client = Client::with_config(config);
 
   // Calculate available tokens using model's context size


### PR DESCRIPTION
Add configurability for OpenAI URL using an environment variable and set up a fake OpenAI service in CI workflow.

* **Configurable OpenAI URL:**
  - Add `openai_host` field to `App` struct in `src/config.rs`.
  - Set default value for `openai_host` in `App::new` method.
  - Update `src/openai.rs` to use `openai_host` from `App` struct.
  - Add `url` subcommand to `config openai set` in `src/main.rs`.
  - Implement `run_config_openai_host` function to handle `url` subcommand.

* **CI Workflow:**
  - Add `services` section in `.github/workflows/ci.yml` to define a fake OpenAI service.
  - Set `OPENAI_API_URL` environment variable to `http://localhost:8080` in the `Run tests` step.
  - Configure the service to expose port 8080.

