### PR TITLE
fix(hook): include diff/hunk headers in collected patch (v1.1.2 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.2] - 2026-06-16
+
+### Fixed
+
+- **Multi-step pipeline broken since v1.1.1**: `collect_diff_data()` dropped git
+  file/hunk header lines (libgit2 origins `'F'`/`'H'`), so the generated patch had no
+  `diff --git`/`@@` markers. `parse_diff()` could then no longer split the diff into
+  per-file sections and collapsed every commit into a single `"unknown"` file, producing
+  generic commit messages. Headers are now preserved. (#91)
+- Annotated an `f32` literal in `model::run()` so the crate builds clean under the latest
+  nightly (the new `float_literal_f32_fallback` lint).
+
+### Tests
+
+- Added real-git2 regression tests (`tests/patch_test.rs`) asserting headers are preserved
+  and that `to_patch()` output parses back into the correct per-file sections (never
+  `"unknown"`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git-ai"
-version = "1.1.0"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-ai"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "Git AI: Automates commit messages using ChatGPT. Stage your files, and Git AI generates the messages."
 license = "MIT"

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -367,9 +367,16 @@ impl PatchDiff for Diff<'_> {
           }
           entry.push_str(&content);
         }
+        'F' | 'H' => {
+          // File headers (diff --git, index, ---, +++) and hunk headers (@@ ... @@) carry the
+          // structure parse_diff() needs to split the patch into per-file sections. Dropping them
+          // (the v1.1.1 regression) collapsed every diff into a single "unknown" file.
+          let entry = files
+            .entry(path)
+            .or_insert_with(|| String::with_capacity(DEFAULT_STRING_CAPACITY));
+          entry.push_str(&content);
+        }
         _ => {
-          // Other lines (headers, etc.) - skip them as they're not part of the actual diff content
-          // The git diff headers are already included by the diff format
           log::trace!("Skipping diff line with origin: {:?}", line.origin());
         }
       }

--- a/src/model.rs
+++ b/src/model.rs
@@ -275,7 +275,7 @@ pub async fn run(settings: AppConfig, content: String) -> Result<String> {
   }
 
   // TODO: Make temperature configurable
-  let temperature_value = 0.7;
+  let temperature_value = 0.7_f32;
 
   log::info!(
     "Using model: {}, Tokens: {}, Max tokens: {}, Temperature: {}",

--- a/tests/patch_test.rs
+++ b/tests/patch_test.rs
@@ -352,8 +352,14 @@ fn test_collect_diff_data_includes_headers() {
   // Must contain hunk header
   assert!(patch.contains("@@"), "collect_diff_data() must include hunk headers (@@), got:\n{patch}");
 
-  // Must also still contain content lines
-  assert!(patch.lines().any(|l| l.starts_with('+')), "Should still contain addition lines");
+  // Must contain a real added *content* line — not just the `+++` file header.
+  // (A bare `starts_with('+')` check would be satisfied by `+++ b/auth.rs`.)
+  assert!(
+    patch
+      .lines()
+      .any(|l| l.starts_with('+') && !l.starts_with("+++") && l.contains("validate()")),
+    "Should contain the added content line (+...validate()...), got:\n{patch}"
+  );
 }
 
 #[test]

--- a/tests/patch_test.rs
+++ b/tests/patch_test.rs
@@ -312,3 +312,137 @@ fn test_diff_only_deletions() {
     "Should contain '-delete line 2'"
   );
 }
+
+#[test]
+fn test_collect_diff_data_includes_headers() {
+  // Regression test: collect_diff_data() must include file and hunk headers
+  // so that parse_diff() can split the output into per-file sections.
+  // Previously, headers were stripped, causing all commits to be treated
+  // as a single "unknown" file in the multi-step analysis pipeline.
+  let repo = TestRepo::default();
+
+  let file = repo.create_file("auth.rs", "fn login() {}\n").unwrap();
+  file.stage().unwrap();
+  file.commit().unwrap();
+
+  // Modify the file
+  let file = repo
+    .create_file("auth.rs", "fn login() { validate(); }\n")
+    .unwrap();
+  file.stage().unwrap();
+
+  let repo_path = repo.repo_path.path().to_path_buf();
+  let git_repo = git2::Repository::open(&repo_path).unwrap();
+  let tree = git_repo.head().unwrap().peel_to_tree().unwrap();
+  let diff = TestRepository::to_diff(&git_repo, Some(tree)).unwrap();
+
+  use std::path::PathBuf;
+
+  use ai::hook::PatchDiff;
+  let diff_data = diff.collect_diff_data().unwrap();
+  let path = PathBuf::from("auth.rs");
+  let patch = diff_data.get(&path).expect("Should contain auth.rs");
+
+  // Must contain diff header for parse_diff() to work
+  assert!(
+    patch.contains("diff --git"),
+    "collect_diff_data() must include file headers (diff --git), got:\n{patch}"
+  );
+
+  // Must contain hunk header
+  assert!(patch.contains("@@"), "collect_diff_data() must include hunk headers (@@), got:\n{patch}");
+
+  // Must also still contain content lines
+  assert!(patch.lines().any(|l| l.starts_with('+')), "Should still contain addition lines");
+}
+
+#[test]
+fn test_collect_diff_data_multi_file_headers() {
+  // Verify that each file in a multi-file diff gets its own headers,
+  // enabling parse_diff() to split them correctly.
+  let repo = TestRepo::default();
+
+  let f1 = repo.create_file("file_a.rs", "fn a() {}\n").unwrap();
+  f1.stage().unwrap();
+  let f2 = repo.create_file("file_b.rs", "fn b() {}\n").unwrap();
+  f2.stage().unwrap();
+  f1.commit().unwrap();
+
+  // Modify both files
+  let f1 = repo.create_file("file_a.rs", "fn a() { 1 }\n").unwrap();
+  f1.stage().unwrap();
+  let f2 = repo.create_file("file_b.rs", "fn b() { 2 }\n").unwrap();
+  f2.stage().unwrap();
+
+  let repo_path = repo.repo_path.path().to_path_buf();
+  let git_repo = git2::Repository::open(&repo_path).unwrap();
+  let tree = git_repo.head().unwrap().peel_to_tree().unwrap();
+  let diff = TestRepository::to_diff(&git_repo, Some(tree)).unwrap();
+
+  use std::path::PathBuf;
+
+  use ai::hook::PatchDiff;
+  let diff_data = diff.collect_diff_data().unwrap();
+
+  // Both files should have their own diff headers
+  let pa = PathBuf::from("file_a.rs");
+  let pb = PathBuf::from("file_b.rs");
+  let patch_a = diff_data.get(&pa).expect("Should contain file_a.rs");
+  let patch_b = diff_data.get(&pb).expect("Should contain file_b.rs");
+
+  assert!(patch_a.contains("diff --git"), "file_a.rs should have its own diff header");
+  assert!(patch_b.contains("diff --git"), "file_b.rs should have its own diff header");
+}
+
+#[test]
+fn test_to_patch_output_parseable_by_parse_diff() {
+  // End-to-end test: the output of to_patch() must be parseable by
+  // parse_diff() into correct per-file sections. This tests the full
+  // pipeline that was previously broken.
+  let repo = TestRepo::default();
+
+  let f1 = repo.create_file("main.rs", "fn main() {}\n").unwrap();
+  f1.stage().unwrap();
+  let f2 = repo.create_file("lib.rs", "pub fn hello() {}\n").unwrap();
+  f2.stage().unwrap();
+  f1.commit().unwrap();
+
+  // Modify both files
+  let f1 = repo
+    .create_file("main.rs", "fn main() { hello(); }\n")
+    .unwrap();
+  f1.stage().unwrap();
+  let f2 = repo
+    .create_file("lib.rs", "pub fn hello() { println!(\"hi\"); }\n")
+    .unwrap();
+  f2.stage().unwrap();
+
+  let repo_path = repo.repo_path.path().to_path_buf();
+  let git_repo = git2::Repository::open(&repo_path).unwrap();
+  let tree = git_repo.head().unwrap().peel_to_tree().unwrap();
+
+  // Generate patch via the same path the hook uses
+  use ai::hook::PatchRepository;
+  let patch = git_repo
+    .to_patch(Some(tree), 4096, ai::model::Model::default())
+    .unwrap();
+
+  // Now parse it the same way multi_step_integration does
+  use ai::multi_step_integration::parse_diff;
+  let parsed = parse_diff(&patch).unwrap();
+
+  // Must produce 2 files with correct paths — NOT a single "unknown" file
+  assert!(
+    parsed.len() == 2,
+    "parse_diff should find 2 files, got {} file(s): {:?}",
+    parsed.len(),
+    parsed.iter().map(|f| &f.path).collect::<Vec<_>>()
+  );
+
+  let paths: Vec<&str> = parsed.iter().map(|f| f.path.as_str()).collect();
+  assert!(paths.contains(&"main.rs"), "Should contain main.rs, got: {paths:?}");
+  assert!(paths.contains(&"lib.rs"), "Should contain lib.rs, got: {paths:?}");
+
+  // None should be "unknown" (the old broken fallback)
+  assert!(!paths.contains(&"unknown"), "Should NOT fall back to 'unknown' file, got: {paths:?}");
+}


### PR DESCRIPTION
## What
Restores the `'F' | 'H'` line-origin handling in `collect_diff_data()` so file/hunk headers (`diff --git`, `@@`, `---`/`+++`) are preserved in the generated patch.

## Why
Regression since **v1.1.1** (#56, `9592ee2`): without headers, `parse_diff()` collapses every diff into a single `"unknown"` file, breaking the multi-step pipeline and producing generic commit messages.

## Reproduction (red → green)
Reverting the header arm makes the new test fail: `parse_diff should find 2 files, got 1 file(s): ["unknown"]`. With the fix, all 3 regression tests pass.

## Changes bundled (all required to ship a green 1.1.2)
- `src/hook.rs` — the header fix (the actual regression fix).
- `tests/patch_test.rs` — real-git2 regression tests.
- `src/model.rs` — annotate `0.7_f32` so the crate builds under the latest nightly (new `float_literal_f32_fallback` lint was turning **all** CI red). Behavior-identical; the dead `model::run()` fn is removed in the 1.2.0 cleanup.
- `Cargo.toml` / `Cargo.lock` — version bump to **1.1.2**.
- `CHANGELOG.md` — new changelog documenting the fix.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)